### PR TITLE
add support for wagtail's css variables

### DIFF
--- a/src/scss/components/c-sf-add-button.scss
+++ b/src/scss/components/c-sf-add-button.scss
@@ -4,6 +4,7 @@
     appearance: none;
     border: 0 none;
     color: $teal;
+    color: var(--color-primary, $teal);
     font-weight: bold;
     background: none;
     padding: 0;

--- a/src/scss/components/c-sf-button.scss
+++ b/src/scss/components/c-sf-button.scss
@@ -16,6 +16,7 @@
     &:hover,
     &:focus {
         background-color: $teal;
+        background-color: var(--color-primary, $teal);
 
         #{$root}__icon,
         #{$root}__label {


### PR DESCRIPTION
Related to https://github.com/wagtail/wagtail/pull/6409

As noted in [this comment](https://github.com/wagtail/wagtail/pull/6409#issuecomment-739351779), the streamfield buttons don't respect changes to wagtail's css variables. This PR is intended to fix that, if appropriate.

What I've included here is the minimum viable fix - just duplicate the declarations! No changes to build tools, no loss of IE support, very simple. Will not scale well (would need 2 declarations every time the `$teal` color is used)... but maybe it doesn't need to?

If instead I were to solve this like the Wagtail PR does, I would have to re-declare the `--color-primary` variable in this repo and trust that this stylesheet would always be imported before (and thus, overridden by) Wagtail's stylesheet.

The main reason I'm opening this is to ask: is this good enough? If not, what kinda solution would make the maintainers most comfortable?

cc @thibaudcolas 